### PR TITLE
WIP: bootstrap sv2 (blocker: sri doesn't export libs)

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -18,6 +18,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +127,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "async_zmq"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +220,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "binary_codec_sv2"
+version = "0.1.4"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+
+[[package]]
+name = "binary_sv2"
+version = "0.1.6"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_codec_sv2",
+ "derive_codec_sv2",
+ "tracing",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1 0.24.3",
+]
+
+[[package]]
 name = "bitcoin"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,9 +253,9 @@ checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
 dependencies = [
  "bech32",
  "bitcoin-private",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
 ]
 
@@ -151,6 +264,12 @@ name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -170,7 +289,7 @@ checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
 dependencies = [
  "bitcoin-private",
  "bitcoincore-rpc-json",
- "jsonrpc",
+ "jsonrpc 0.14.1",
  "log",
  "serde",
  "serde_json",
@@ -182,7 +301,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.1",
  "bitcoin-private",
  "serde",
  "serde_json",
@@ -194,7 +313,7 @@ version = "1.3.0"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#ab598112f3e9cf3370f46fc75ee3c3f579bb8afd"
 dependencies = [
  "async_zmq",
- "bitcoin",
+ "bitcoin 0.30.1",
  "futures-util",
  "zmq",
 ]
@@ -212,9 +331,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "braidpool-node"
 version = "0.1.0"
 dependencies = [
+ "async-channel 2.1.1",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "bitcoincore-zmq",
@@ -223,6 +352,7 @@ dependencies = [
  "env_logger",
  "flexbuffers",
  "futures",
+ "jd_server",
  "log",
  "serde",
  "serde_derive",
@@ -230,8 +360,26 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml 0.8.8",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
+name = "buffer_sv2"
+version = "0.1.2"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "aes-gcm",
 ]
 
 [[package]]
@@ -279,6 +427,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,10 +502,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "codec_sv2"
+version = "1.0.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "buffer_sv2",
+ "const_sv2",
+ "framing_sv2",
+ "noise_sv2",
+ "tracing",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "common_messages_sv2"
+version = "0.1.5"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "const_sv2",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const_sv2"
+version = "0.1.2"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crossbeam"
@@ -392,6 +620,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "derive_codec_sv2"
+version = "0.1.3"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_codec_sv2",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "dircpy"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +703,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "error_handling"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "flexbuffers"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +745,15 @@ dependencies = [
  "num_enum",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "framing_sv2"
+version = "0.1.5"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -557,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,11 +901,31 @@ checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "hashbrown"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
+dependencies = [
+ "ahash 0.3.8",
+ "autocfg",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -601,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +972,15 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -649,6 +1010,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jd_server"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-recursion",
+ "binary_sv2",
+ "buffer_sv2",
+ "codec_sv2",
+ "const_sv2",
+ "error_handling",
+ "hashbrown 0.11.2",
+ "hex",
+ "jsonrpc 0.16.0",
+ "key-utils",
+ "network_helpers",
+ "nohash-hasher",
+ "noise_sv2",
+ "rand",
+ "roles_logic_sv2",
+ "secp256k1 0.27.0",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "stratum-common",
+ "tokio",
+ "toml 0.5.6",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "job_declaration_sv2"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "const_sv2",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +1064,16 @@ name = "jsonrpc"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.16.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
 dependencies = [
  "base64",
  "serde",
@@ -689,6 +1101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "key-utils"
+version = "1.0.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "bs58",
+ "secp256k1 0.27.0",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +1127,16 @@ name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -734,6 +1166,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mining_sv2"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "const_sv2",
 ]
 
 [[package]]
@@ -799,6 +1240,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "network_helpers"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-trait",
+ "binary_sv2",
+ "codec_sv2",
+ "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "noise_sv2"
+version = "1.0.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "aes-gcm",
+ "chacha20poly1305",
+ "const_sv2",
+ "rand",
+ "rand_chacha",
+ "secp256k1 0.27.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,10 +1329,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -877,6 +1386,29 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -963,6 +1495,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1548,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "roles_logic_sv2"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "chacha20poly1305",
+ "common_messages_sv2",
+ "const_sv2",
+ "framing_sv2",
+ "job_declaration_sv2",
+ "mining_sv2",
+ "nohash-hasher",
+ "siphasher",
+ "stratum-common",
+ "template_distribution_sv2",
+ "tracing",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,14 +1608,33 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
+ "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.12.0",
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1100,11 +1679,24 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1115,6 +1707,21 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ac45299ccbd390721be55b412d41931911f654fa99e2cb8bfb57184b2061fe"
 
 [[package]]
 name = "slab"
@@ -1172,10 +1779,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "stratum-common"
+version = "0.1.0"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "bitcoin 0.29.2",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -1208,7 +1829,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.8",
  "version-compare",
 ]
 
@@ -1217,6 +1838,15 @@ name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
+name = "template_distribution_sv2"
+version = "0.1.5"
+source = "git+https://github.com/stratum-mining/stratum.git?branch=dev#b0eb6db9f0318c94654887a34b186e8533470681"
+dependencies = [
+ "binary_sv2",
+ "const_sv2",
+]
 
 [[package]]
 name = "termcolor"
@@ -1268,7 +1898,9 @@ dependencies = [
  "libc",
  "mio 0.8.8",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",
@@ -1317,21 +1949,30 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.5.6"
+source = "git+https://github.com/diondokter/toml-rs?rev=c4161aa#c4161aa70202b3992dbec79b76e7a8659713b604"
+dependencies = [
+ "hashbrown 0.7.2",
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.2",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -1349,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
  "indexmap",
  "serde",
@@ -1414,6 +2055,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -1421,10 +2063,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1593,6 +2251,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zeromq-src"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,3 +23,7 @@ bitcoincore-rpc-json = { version = "0.17.0" }
 bitcoincore-zmq = { version = "1.2.0", git = "https://github.com/antonilol/rust-bitcoincore-zmq.git", features = ["async"] }
 env_logger = "0.10.0"
 log = "0.4.16"
+toml = "0.8.8"
+async-channel = "2.1.1"
+jd_server = { git = "https://github.com/stratum-mining/stratum.git", branch = "dev" }
+#pool_sv2 = { git = "https://github.com/stratum-mining/stratum.git", branch = "dev" }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -10,6 +10,7 @@ mod cli;
 mod connection;
 mod protocol;
 mod rpc;
+mod sv2;
 mod zmq;
 
 #[tokio::main]
@@ -33,6 +34,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (block_template_tx, block_template_rx) = mpsc::channel(1);
     tokio::spawn(zmq::zmq_hashblock_listener(zmq_url, rpc, block_template_tx));
     tokio::spawn(block_template::consumer(block_template_rx));
+
+    // SV2
+    tokio::spawn(sv2::jd_server::jd_server());
+    tokio::spawn(sv2::jd_server::pool());
 
     if let Some(addnode) = args.addnode {
         for node in addnode.iter() {

--- a/node/src/sv2.rs
+++ b/node/src/sv2.rs
@@ -1,0 +1,4 @@
+mod jds;
+mod pool;
+
+pub use jds::jd_server;

--- a/node/src/sv2/config/jd-server-config.toml
+++ b/node/src/sv2/config/jd-server-config.toml
@@ -1,0 +1,24 @@
+# SRI Pool config
+authority_public_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+authority_secret_key = "7qbpUjScc865jyX2kiB4NVJANoC7GA7TAJupdzXWkc62"
+cert_validity_sec = 3600
+
+# List of coinbase outputs used to build the coinbase tx
+# ! Right now only one output is supported, so comment all the ones you don't need !
+# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.
+coinbase_outputs = [
+    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
+    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
+    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
+    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
+    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+
+# SRI Pool JD config
+listen_jd_address = "127.0.0.1:34264"
+# RPC config for mempool (it can be also the same TP if correctly configured)
+core_rpc_url =  "http://127.0.0.1"
+core_rpc_port = 18332
+core_rpc_user =  "braidpooldev"
+core_rpc_pass =  "braidpooldev"

--- a/node/src/sv2/config/pool-sv2-config.toml
+++ b/node/src/sv2/config/pool-sv2-config.toml
@@ -1,0 +1,29 @@
+# SRI Pool config
+authority_public_key = "3VANfft6ei6jQq1At7d8nmiZzVhBFS4CiQujdgim1ign"
+authority_secret_key = "7qbpUjScc865jyX2kiB4NVJANoC7GA7TAJupdzXWkc62"
+cert_validity_sec = 3600
+test_only_listen_adress_plain =  "0.0.0.0:34250"
+listen_address = "0.0.0.0:34254"
+
+# List of coinbase outputs used to build the coinbase tx
+# ! Right now only one output is supported, so comment all the ones you don't need !
+# For P2PK, P2PKH, P2WPKH, P2TR a public key is needed. For P2SH and P2WSH, a redeem script is needed.
+coinbase_outputs = [
+    #{ output_script_type = "P2PK", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
+    #{ output_script_type = "P2PKH", output_script_value = "0372c47307e5b75ce365daf835f226d246c5a7a92fe24395018d5552123354f086" },
+    #{ output_script_type = "P2SH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
+    #{ output_script_type = "P2WSH", output_script_value = "00142ef89234bc95136eb9e6fee9d32722ebd8c1f0ab" },
+    { output_script_type = "P2WPKH", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+    #{ output_script_type = "P2TR", output_script_value = "036adc3bdf21e6f9a0f0fb0066bf517e5b7909ed1563d6958a10993849a7554075" },
+]
+
+# Pool signature (string to be included in coinbase tx)
+pool_signature = "Stratum v2 SRI Pool"
+
+# Template Provider config
+# Local TP (this is pointing to localhost so you must run a TP locally for this configuration to work)
+#tp_address = "127.0.0.1:8442"
+# Hosted testnet TP
+tp_address = "192.168.0.63:8442"
+# Hosted regtest TP
+# tp_address = "75.119.150.111:8442"

--- a/node/src/sv2/jds.rs
+++ b/node/src/sv2/jds.rs
@@ -1,0 +1,89 @@
+use jd_server::lib::*;
+
+pub async fn jd_server() {
+    // Load config
+    let config_path = "./config/jd-server-config.toml";
+
+    let config: jd_server::Configuration = match std::fs::read_to_string(config_path) {
+        Ok(c) => match toml::from_str(&c) {
+            Ok(c) => c,
+            Err(e) => {
+                log::error!("Failed to parse config:{:?}", e);
+                return;
+            }
+        },
+        Err(e) => {
+            log::error!("Failed to read config: {}", e);
+            return;
+        }
+    };
+
+    let url = config.core_rpc_url.clone() + ":" + &config.core_rpc_port.clone().to_string();
+    let username = config.core_rpc_user.clone();
+    let password = config.core_rpc_pass.clone();
+    let mempool = std::sync::Arc::new(tokio::sync::Mutex::new(jd_server::lib::mempool::JDsMempool::new(
+        url.clone(),
+        username,
+        password,
+    )));
+    let mempool_cloned_ = mempool.clone();
+    if url.contains("http") {
+        tokio::task::spawn(async move {
+            loop {
+                let _ = jd_server::mempool::JDsMempool::update_mempool(mempool_cloned_.clone()).await;
+                // TODO this should be configurable by the user
+                tokio::time::sleep(tokio::time::Duration::from_millis(10000)).await;
+            }
+        });
+    };
+
+    let (status_tx, status_rx) = async_channel::unbounded();
+    log::info!("Jds INITIALIZING with config: {:?}", config_path);
+
+    let cloned = config.clone();
+    let sender = jd_server::status::Sender::Downstream(status_tx.clone());
+    let mempool_cloned = mempool.clone();
+    tokio::task::spawn(async move { jd_server::lib::job_declarator::JobDeclarator::start(cloned, sender, mempool_cloned).await });
+
+    // Start the error handling loop
+    // See `./status.rs` and `utils/error_handling` for information on how this operates
+    loop {
+        let task_status = tokio::select! {
+            task_status = status_rx.recv() => task_status,
+            interrupt_signal = tokio::signal::ctrl_c() => {
+                match interrupt_signal {
+                    Ok(()) => {
+                        log::info!("Interrupt received");
+                    },
+                    Err(err) => {
+                        log::error!("Unable to listen for interrupt signal: {}", err);
+                        log::error!("Halting.");
+                        std::process::exit(1);
+                    },
+                }
+                break;
+            }
+        };
+        let task_status: jd_server::status::Status = task_status.unwrap();
+
+        match task_status.state {
+            // Should only be sent by the downstream listener
+            jd_server::status::State::DownstreamShutdown(err) => {
+                log::error!(
+                    "SHUTDOWN from Downstream: {}\nTry to restart the downstream listener",
+                    err
+                );
+            }
+            jd_server::status::State::TemplateProviderShutdown(err) => {
+                log::error!("SHUTDOWN from Upstream: {}\nTry to reconnecting or connecting to a new upstream", err);
+                break;
+            }
+            jd_server::status::State::Healthy(msg) => {
+                log::info!("HEALTHY message: {}", msg);
+            }
+            jd_server::status::State::DownstreamInstanceDropped(downstream_id) => {
+                log::warn!("Dropping downstream instance {} from jds", downstream_id);
+            }
+        }
+    }
+}

--- a/node/src/sv2/pool.rs
+++ b/node/src/sv2/pool.rs
@@ -1,0 +1,1 @@
+// pub use pool_sv2::lib::*;


### PR DESCRIPTION
This is a WIP integration between `braidpool-node` and SRI crates.

[SV2 has 5 different role types](https://stratumprotocol.org/specification/03-Protocol-Overview/):

1. `mining device`: ASIC
2. `template provider`: `bitcoind` executable
3. `pool service`: does share accounting, publishes valid blocks, `pool_sv2` executable
4. `job declarator`: optional, useful for miner-defined templates, `jd_server` executable
5. `mining proxy`: optional, useful as a fan-in share relayer in ASIC farms and SV1/SV2 translation), `mining_proxy_sv2`, `translator_sv2` executables

The goal is to consume SRI APIs so that `braidpool-node` implements:
- `pool service` role: share/bead accounting and publishes valid blocks.
- `job declarator` role: sets the template coinbase (while following [Braidpool's `FROST` rules](https://blog.opdup.com/2023/08/22/frost-for-braidpool.html)) and distributes this work to downstream miners.

This PoC is currently blocked by the fact that SRI doesn't yet export APIs.
`jd_server` and `pool_sv2` modules cannot be imported as `lib`.